### PR TITLE
Gcamdata china

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(person("Ben", "Bond-Lamberty",
   person("Robert", "Link",        role = "aut"),
   person("Pralit", "Patel",       role = "aut", comment = c(ORCID = "0000-0003-3992-1061")))
 Description: Output products of the gcamdata package suitable for old/new comparison tests.
-Depends: R (>= 3.4.2)
+Depends: R (>= 3.1.2)
 License: ECL2 + file LICENSE
 Encoding: UTF-8
 LazyData: false

--- a/outputs/L100.GDP_mil90usd_province.csv
+++ b/outputs/L100.GDP_mil90usd_province.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:135ec937b7c2b1f1910efae33365f2a0567073b32a69ca06b0b3083fb6e90071
+size 108999

--- a/outputs/L100.Pop_thous_province.csv
+++ b/outputs/L100.Pop_thous_province.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcf6f93e5e874376550a8faf96fbe11404ed260258e239220dfc2815a7c2ff02
+size 89623

--- a/outputs/L100.pcGDP_thous90usd_province.csv
+++ b/outputs/L100.pcGDP_thous90usd_province.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:547fe64fb3e37bdddc163d6a5bcbc6a0cb3c14dc0edbab8fd17c475e08d180d0
+size 109920

--- a/outputs/L101.NBS_use_all_Mtce.csv
+++ b/outputs/L101.NBS_use_all_Mtce.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df917cf6d2d930b54117f1301a9e2416fc0f39f9822bdb9a203fe8fc38a45045
-size 3674039
+oid sha256:67e29be8dc574f4bdb762c9ce9c17d52055c15ef5853d31002e1979d10ca2bd4
+size 38721989

--- a/outputs/L101.NBS_use_all_Mtce.csv
+++ b/outputs/L101.NBS_use_all_Mtce.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df917cf6d2d930b54117f1301a9e2416fc0f39f9822bdb9a203fe8fc38a45045
+size 3674039

--- a/outputs/L101.NBS_use_all_Mtce.csv
+++ b/outputs/L101.NBS_use_all_Mtce.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67e29be8dc574f4bdb762c9ce9c17d52055c15ef5853d31002e1979d10ca2bd4
+oid sha256:405abaf1666c80daa35511b9c46267bda510c902de4cdcd14243ef487b3e0a09
 size 38721989

--- a/outputs/L101.inNBS_Mtce_province_S_F.csv
+++ b/outputs/L101.inNBS_Mtce_province_S_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7574a2a8159d24bb3cc6f949bbde0f389ac607db9462e29f872cbd5d6d08c45c
+size 384548

--- a/outputs/L101.inNBS_Mtce_province_S_F.csv
+++ b/outputs/L101.inNBS_Mtce_province_S_F.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d02dbfda7b070c2cb31d04242b363e2667f16e65c51d2e8a9d2a49f7e6fa1550
+oid sha256:24fd52a49e745ee1a27083f452bfe7af6b3418673788f4a5834005a4bf732cb3
 size 2139158

--- a/outputs/L101.inNBS_Mtce_province_S_F.csv
+++ b/outputs/L101.inNBS_Mtce_province_S_F.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7574a2a8159d24bb3cc6f949bbde0f389ac607db9462e29f872cbd5d6d08c45c
-size 384548
+oid sha256:d02dbfda7b070c2cb31d04242b363e2667f16e65c51d2e8a9d2a49f7e6fa1550
+size 2139158

--- a/outputs/L114.CapacityFactor_wind_province.csv
+++ b/outputs/L114.CapacityFactor_wind_province.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16374580acdc535d520cf052cd370b13a16d278f0e3e8e5c8b01fbd4b4a8c266
+size 1995

--- a/outputs/L119.CapFacScaler_CSP_province.csv
+++ b/outputs/L119.CapFacScaler_CSP_province.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b22048e9fd26834b1dd8bf6e212a34f9dd5d0d57ce2f255c2c6125aa09287e43
+size 2078

--- a/outputs/L119.CapFacScaler_PV_province.csv
+++ b/outputs/L119.CapFacScaler_PV_province.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46a0bba84f047ac3fccbf588805db459fb1db9079d3bcfe3a3e2be0d49540c89
+size 2031

--- a/outputs/L122.in_EJ_province_refining_F.csv
+++ b/outputs/L122.in_EJ_province_refining_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e257ec5cf56b2bc5695e2f06f3340389feb26cb371e12a596c0e2b9be44e447f
+size 331552

--- a/outputs/L122.out_EJ_province_refining_F.csv
+++ b/outputs/L122.out_EJ_province_refining_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2550582aa078674a91083c1d357364da7d69e6034037f6efab45a4ed167d25da
+size 132826

--- a/outputs/L123.in_EJ_province_elec_F.csv
+++ b/outputs/L123.in_EJ_province_elec_F.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c134045d72194884d2014a94e32d5cd951b073d5cd0bf0350fd71ef0cce5cd58
-size 267150
+oid sha256:f298b0bee293db9bdb40162a15a11d292437f3695d1b1a4fa4faa3b786b46246
+size 243157

--- a/outputs/L123.in_EJ_province_elec_F.csv
+++ b/outputs/L123.in_EJ_province_elec_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c134045d72194884d2014a94e32d5cd951b073d5cd0bf0350fd71ef0cce5cd58
+size 267150

--- a/outputs/L123.in_EJ_province_ownuse_elec.csv
+++ b/outputs/L123.in_EJ_province_ownuse_elec.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6cb4015fc339fa69728dbbc306b99fe9afdc73089ff9325c718ea1f166d0ca6
+size 71473

--- a/outputs/L123.in_EJ_province_ownuse_elec.csv
+++ b/outputs/L123.in_EJ_province_ownuse_elec.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6cb4015fc339fa69728dbbc306b99fe9afdc73089ff9325c718ea1f166d0ca6
-size 71473
+oid sha256:753e5c90ea9db3be3141b8d248849b7a4951c553b219144c22e88cf4226e8e34
+size 64359

--- a/outputs/L123.out_EJ_province_elec_F.csv
+++ b/outputs/L123.out_EJ_province_elec_F.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc4308a6e9a4e5bb39bd71158fc033cfdff821094973a05e85e76d958c9dd66a
-size 546255
+oid sha256:642e07d0de7d1e8522eaa93cb95560a53a9477ae77531ca060ae9a674754426f
+size 515728

--- a/outputs/L123.out_EJ_province_elec_F.csv
+++ b/outputs/L123.out_EJ_province_elec_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc4308a6e9a4e5bb39bd71158fc033cfdff821094973a05e85e76d958c9dd66a
+size 546255

--- a/outputs/L123.out_EJ_province_ownuse_elec.csv
+++ b/outputs/L123.out_EJ_province_ownuse_elec.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bd1d257c75e7665d15d48d8197d28baba6f9385cfcd2a04d541aaf8aea83c713
-size 71515
+oid sha256:406cd1755e01b39c245fae04cdecea78e55f17b0dbd885fb19b6a9a59a19ba57
+size 64373

--- a/outputs/L123.out_EJ_province_ownuse_elec.csv
+++ b/outputs/L123.out_EJ_province_ownuse_elec.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd1d257c75e7665d15d48d8197d28baba6f9385cfcd2a04d541aaf8aea83c713
+size 71515

--- a/outputs/L1231.in_EJ_province_elec_F_tech.csv
+++ b/outputs/L1231.in_EJ_province_elec_F_tech.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:985e554da99526bb77cd394d340c8a9659821dacbbc25ad40319a53cdbecf6cc
+size 422206

--- a/outputs/L1231.in_EJ_province_elec_F_tech.csv
+++ b/outputs/L1231.in_EJ_province_elec_F_tech.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:985e554da99526bb77cd394d340c8a9659821dacbbc25ad40319a53cdbecf6cc
-size 422206
+oid sha256:d37de22e5f9dddf29b26eb722da946f6445af1238110e39293219776c30e519a
+size 395920

--- a/outputs/L1231.out_EJ_province_elec_F_tech.csv
+++ b/outputs/L1231.out_EJ_province_elec_F_tech.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c8db1278958ccb22af310b97d3025ecea048397c5b6b8f83cacc3d6fe6f504a
-size 804243
+oid sha256:e9ae9b5f272a56e0892af0c22926d57ee2f34d7efd29b4b54adddc2db8d0f778
+size 772514

--- a/outputs/L1231.out_EJ_province_elec_F_tech.csv
+++ b/outputs/L1231.out_EJ_province_elec_F_tech.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c8db1278958ccb22af310b97d3025ecea048397c5b6b8f83cacc3d6fe6f504a
+size 804243

--- a/outputs/L1232.out_EJ_sR_elec.csv
+++ b/outputs/L1232.out_EJ_sR_elec.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a8bbc189ea8b850783dc723d9e9f9f1058da459818511e261c4e5c3ec440043b
-size 15823
+oid sha256:244bb669930dd2f4a49df7cd8bdf46cb77608b741c823da4674ed5a78f3ae3e9
+size 38208

--- a/outputs/L1232.out_EJ_sR_elec.csv
+++ b/outputs/L1232.out_EJ_sR_elec.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:244bb669930dd2f4a49df7cd8bdf46cb77608b741c823da4674ed5a78f3ae3e9
-size 38208
+oid sha256:a8bbc189ea8b850783dc723d9e9f9f1058da459818511e261c4e5c3ec440043b
+size 15823

--- a/outputs/L1232.out_EJ_sR_elec_CHINA.csv
+++ b/outputs/L1232.out_EJ_sR_elec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8bbc189ea8b850783dc723d9e9f9f1058da459818511e261c4e5c3ec440043b
+size 15823

--- a/outputs/L1232.out_EJ_sR_elec_CHINA.csv
+++ b/outputs/L1232.out_EJ_sR_elec_CHINA.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a8bbc189ea8b850783dc723d9e9f9f1058da459818511e261c4e5c3ec440043b
-size 15823
+oid sha256:5cf7adf5ceacecf41bc5bd8627be4b8d29f0206430e33281052413f6ecf328c9
+size 14644

--- a/outputs/L126.in_EJ_province_gasproc_F.csv
+++ b/outputs/L126.in_EJ_province_gasproc_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c95fbca8d30cf3ec16c3bc63ebcb1f35a3a47081292d247be58423d09eafd39e
+size 165328

--- a/outputs/L126.in_EJ_province_pipeline_gas.csv
+++ b/outputs/L126.in_EJ_province_pipeline_gas.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d03fb280cf8f8a8405b6d644a6f18cc3ed7d0856da92fe016d78ea703d4bee7b
+size 55300

--- a/outputs/L126.in_EJ_province_td_elec.csv
+++ b/outputs/L126.in_EJ_province_td_elec.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d320f840aada5b70e591aa8e3da872ca74856279fff7afa8b246225ad0953eab
+size 61556

--- a/outputs/L126.out_EJ_province_gasproc_F.csv
+++ b/outputs/L126.out_EJ_province_gasproc_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40c46615a5a87b4c8d12d214a88533c4a6be2743ec746466dd917c23c1ac3da9
+size 165360

--- a/outputs/L126.out_EJ_province_pipeline_gas.csv
+++ b/outputs/L126.out_EJ_province_pipeline_gas.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3a961a195bae911624c67db20983813f3a0f3c5809ec1aac9ce09d2914713f4
+size 57026

--- a/outputs/L126.out_EJ_province_td_elec.csv
+++ b/outputs/L126.out_EJ_province_td_elec.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b7607de7df8a18de8af16e9f35d2d7c8d33714adea5865a813e9024ad22c335
+size 61602

--- a/outputs/L132.in_EJ_province_indchp_F.csv
+++ b/outputs/L132.in_EJ_province_indchp_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:497510b2eb7e17f43515ef190b57d038a26f8d44457b2a30bcf1ab32d13c0f49
+size 135192

--- a/outputs/L132.in_EJ_province_indfeed_F.csv
+++ b/outputs/L132.in_EJ_province_indfeed_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f09559ab3866491126050aedd344986fea41c260e040fdee074396cf32f00b53
+size 169214

--- a/outputs/L132.in_EJ_province_indnochp_F.csv
+++ b/outputs/L132.in_EJ_province_indnochp_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f1deb8edadcfa9dd02b686bf4cd4fffecd0687a96add1dfec6dc1d824317c7
+size 370627

--- a/outputs/L132.out_EJ_province_indchp_F.csv
+++ b/outputs/L132.out_EJ_province_indchp_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:497510b2eb7e17f43515ef190b57d038a26f8d44457b2a30bcf1ab32d13c0f49
+size 135192

--- a/outputs/L1321.IO_GJkg_province_cement_F_Yh.csv
+++ b/outputs/L1321.IO_GJkg_province_cement_F_Yh.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21c7f0bf75e99d48ea38db13fb387f20405bd6e256d38a8ebaa337aa5ea5051f
+size 152056

--- a/outputs/L1321.in_EJ_province_cement_F_Y.csv
+++ b/outputs/L1321.in_EJ_province_cement_F_Y.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f85f5fb4bb8960ccabed3a4f3c4ebfce4bc8950fee419dbae8d626f9e0bb795b
+size 226416

--- a/outputs/L1321.out_Mt_province_cement_Yh.csv
+++ b/outputs/L1321.out_Mt_province_cement_Yh.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36faefa2075ba5de1dabaf5f20974fe2c00ef6f7c6d4cc5d53c6c83106fdce2a
+size 39806

--- a/outputs/L1322.IO_GJkg_province_Fert_F_Yh.csv
+++ b/outputs/L1322.IO_GJkg_province_Fert_F_Yh.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0eed625c7d5512deeae980256e757ad12b31aa00f2e5d7d931de206ce86171a3
+size 158432

--- a/outputs/L1322.in_EJ_province_Fert_Yh.csv
+++ b/outputs/L1322.in_EJ_province_Fert_Yh.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fde9e3c1a5357bd5e44a26e0f685d0041fe0375e587fa75ee0b55091cdb25178
+size 176459

--- a/outputs/L1322.out_Mt_province_Fert_Yh.csv
+++ b/outputs/L1322.out_Mt_province_Fert_Yh.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:094f424ea6c873a4e5b038a2c50797fe24d3d8d6e7401d05dce32efef3aaf05b
+size 173986

--- a/outputs/L142.flsp_bm2_province_bld.csv
+++ b/outputs/L142.flsp_bm2_province_bld.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38b4b387a21968200e804103cc424d1badec73a1c30d96bbfb7eed14b3fedc8a
+size 153522

--- a/outputs/L142.in_EJ_province_bld_F_U.csv
+++ b/outputs/L142.in_EJ_province_bld_F_U.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c8d8a2d39ebfacf4dfc2225180c195fa3c2b2fdffadbcfc81e6eacc135a4127
+size 4478701

--- a/outputs/L154.in_EJ_province_trn_F.csv
+++ b/outputs/L154.in_EJ_province_trn_F.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8eccd814e7c2d967c3a6badc851d808ee5fc990a0419cbc4234e8dbc301d0e4
+oid sha256:142c16c5ed057fcf81061be420c5d10b8721432162d715ac00efe6a585f5cfa5
 size 252352

--- a/outputs/L154.in_EJ_province_trn_F.csv
+++ b/outputs/L154.in_EJ_province_trn_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8eccd814e7c2d967c3a6badc851d808ee5fc990a0419cbc4234e8dbc301d0e4
+size 252352

--- a/outputs/L154.in_EJ_province_trn_m_sz_tech_F.csv
+++ b/outputs/L154.in_EJ_province_trn_m_sz_tech_F.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcb9b27a2329ce4a4261887784ff8e9297615bebeafa17e0f38943321cbfb5c2
+size 3965828

--- a/outputs/L154.in_EJ_province_trn_m_sz_tech_F.csv
+++ b/outputs/L154.in_EJ_province_trn_m_sz_tech_F.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fcb9b27a2329ce4a4261887784ff8e9297615bebeafa17e0f38943321cbfb5c2
-size 3965828
+oid sha256:906ae9118dff368ad4111483f26522208c77b45e6bbe219b10ba601fa6164859
+size 3437330

--- a/outputs/L154.out_mpkm_province_trn_nonmotor_Yh.csv
+++ b/outputs/L154.out_mpkm_province_trn_nonmotor_Yh.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28593a8baaee9ebf067cf436d8e1d264a4580c02ed9f047636d62c72aaaf879d
+size 75417

--- a/outputs/L161.Cstorage_province.csv
+++ b/outputs/L161.Cstorage_province.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:291d3755ce071113e80dbd6c4fa575bf039c375585e05648cfebec2efc28eefe
+size 10013

--- a/outputs/L161.Cstorage_province.csv
+++ b/outputs/L161.Cstorage_province.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:291d3755ce071113e80dbd6c4fa575bf039c375585e05648cfebec2efc28eefe
-size 10013
+oid sha256:7fd90f701370785db4d1feb012dd2a8c238387722a22508794fcacf92e478e7f
+size 9849

--- a/outputs/L201.BaseGDP_GCAMCHINA.csv
+++ b/outputs/L201.BaseGDP_GCAMCHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e26906bd3b568d31cfd33ec7b3c940561d11f1f73a4b612cd29fe35c45ea1c9d
+size 664

--- a/outputs/L201.InterestRate_CHINA.csv
+++ b/outputs/L201.InterestRate_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bab9bf1938bbc91ec2e1416781e792aa12a16578b65d288fac6f9b8c149d098
+size 301

--- a/outputs/L201.LaborForceFillout_CHINA.csv
+++ b/outputs/L201.LaborForceFillout_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00266972fcd828c03d35060cdb7b3bb6b0d1c6f2b13d0844d150c14b6ea9f1e8
+size 435

--- a/outputs/L201.LaborProductivity_GCAMCHINA.csv
+++ b/outputs/L201.LaborProductivity_GCAMCHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5d09133f38a548d08aa0fad6a023013a8cc7f0b3e29afa5f6e78627c05cee23
+size 14294

--- a/outputs/L201.Pop_GCAMCHINA.csv
+++ b/outputs/L201.Pop_GCAMCHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:766e0a6d84dfb32e961a27ab715a710b94beffce17eea7dab6684733927058d2
+size 14268

--- a/outputs/L210.RenewRsrc_CHINA.csv
+++ b/outputs/L210.RenewRsrc_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bb263481c3db864862cc34b9131bc1310eaf6dfcface63c2e8e55a97173ddb6
+size 3187

--- a/outputs/L210.SmthRenewRsrcCurves_wind_CHINA.csv
+++ b/outputs/L210.SmthRenewRsrcCurves_wind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2343136447873131ef7d3467c3ef4f3b6be54d8ebeb61cdbb214095df869ba9
+size 2806

--- a/outputs/L210.UnlimitRsrcPrice_CHINA.csv
+++ b/outputs/L210.UnlimitRsrcPrice_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd2759d484fbffe1af03a0392da67dc1306efb6a247ad7b0b34be708a4705d43
+size 4922

--- a/outputs/L210.UnlimitRsrcPrice_limestone_CHINA.csv
+++ b/outputs/L210.UnlimitRsrcPrice_limestone_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45d9dd01e3e0b3a98c7ea5ea007708d34cd94eca1e2359b809d30750f2e7a57e
+size 3138

--- a/outputs/L210.UnlimitRsrc_CHINA.csv
+++ b/outputs/L210.UnlimitRsrc_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f2e1a05962e4072cba5d111569be86c4a915878ffb0409a8deb7116e423cdab
+size 1542

--- a/outputs/L210.UnlimitRsrc_limestone_CHINA.csv
+++ b/outputs/L210.UnlimitRsrc_limestone_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4f47ec3750853671cde9bb2aa205ef007e5184e6aeffd8f12b344e1a8048bc3
+size 1080

--- a/outputs/L222.CarbonCoef_en_CHINA.csv
+++ b/outputs/L222.CarbonCoef_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebfef03bab4a8118bd62753cf03927a9c1c7f7f9eb83648a3b1cd81b1b257b19
+size 3219

--- a/outputs/L222.DeleteStubTech_CHINAen_CHINA.csv
+++ b/outputs/L222.DeleteStubTech_CHINAen_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ee3fc7ea6b7a88b1b77a7e7b78145c926d9d097c2712e40e938fc7d29cadff9
+size 723

--- a/outputs/L222.EQUIV_TABLE_CHINA.csv
+++ b/outputs/L222.EQUIV_TABLE_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3c038fc6e3145cc949c8edae24dc146744fd94a59cc5e49e05a31c83374efbc
+size 94

--- a/outputs/L222.GlobalTechCapture_en_CHINA.csv
+++ b/outputs/L222.GlobalTechCapture_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef47ab006a0a713d2b1d27584ff5fd3067208e9c02c139d4d4e39a79e0df0726
+size 9273

--- a/outputs/L222.GlobalTechCoef_en_CHINA.csv
+++ b/outputs/L222.GlobalTechCoef_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8777d4244880cd74c91b3a6ba3652f2bef6265f9b34b631ee98c5e23e5cb5e44
+size 32972

--- a/outputs/L222.GlobalTechCost_en_CHINA.csv
+++ b/outputs/L222.GlobalTechCost_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2331b0ff45b148f415e118c7c50253b291e7d1311b824de7544529962c0da1e4
+size 23107

--- a/outputs/L222.GlobalTechInterp_en_CHINA.csv
+++ b/outputs/L222.GlobalTechInterp_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61455d333b46a5b1d621072ca0d269d2f1bfa59c5ea88acbd0a039845de097b6
+size 476

--- a/outputs/L222.GlobalTechSCurve_en_CHINA.csv
+++ b/outputs/L222.GlobalTechSCurve_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a61a72c9d9bf88daec18f290216de3218b95990feb03cb931873a8016057f9be
+size 18066

--- a/outputs/L222.GlobalTechShrwt_en_CHINA.csv
+++ b/outputs/L222.GlobalTechShrwt_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad0fc1d43ac0382c453b57e682f0c5fb2cc5440e35ed4345d6605adf2a8c9720
+size 19060

--- a/outputs/L222.PassThroughSector_CHINAen_CHINA.csv
+++ b/outputs/L222.PassThroughSector_CHINAen_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e702f9fdc8b95d5605614efa436d3d86edfd2ace96795ccec0d4b17fdbce599
+size 4292

--- a/outputs/L222.Production_CHINArefining_CHINA.csv
+++ b/outputs/L222.Production_CHINArefining_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acbc97735f4309a217fd96a22349bd6a154714ed4759a3a82ef715065a3b2054
+size 16650

--- a/outputs/L222.SectorEQUIV_CHINA.csv
+++ b/outputs/L222.SectorEQUIV_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:593b964b93559a13e322c44ee833601636b890feeb393ce45221f3197e7facdd
+size 63

--- a/outputs/L222.StubTechCoef_refining_CHINA.csv
+++ b/outputs/L222.StubTechCoef_refining_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc7bd75a1ecbe74e3a9e71fc18f4e34c5e36a446225deb0749806e09e934ab61
+size 30160

--- a/outputs/L222.StubTechMarket_en_CHINA.csv
+++ b/outputs/L222.StubTechMarket_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5783fa15759a775af1f36af15bf5be9fa76b49f49c7fe065bdba578a93115de3
+size 968525

--- a/outputs/L222.StubTechProd_refining_CHINA.csv
+++ b/outputs/L222.StubTechProd_refining_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:162e041c9ce577ebc8952b92cad9dfde2d16a468476e0311993b10fd455fa398
+size 24351

--- a/outputs/L222.StubTech_en_CHINA.csv
+++ b/outputs/L222.StubTech_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25316e1af1c9b77fa07cc34b0f01e819df73b4eecf599851f5f2986ad3f86d7d
+size 23939

--- a/outputs/L222.SubsectorLogit_absolute-cost-logit_CHINA.csv
+++ b/outputs/L222.SubsectorLogit_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5fc55d9f187d7838c60627f1e798059e867d2ba7421be97d44d073b0a6c12b7
+size 7170

--- a/outputs/L222.SubsectorLogit_en_CHINA.csv
+++ b/outputs/L222.SubsectorLogit_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7869c8a612787e79450ee6a24ceaca9e16d823cec9574bd02cb536bfb0238192
+size 5609

--- a/outputs/L222.SubsectorLogit_relative-cost-logit_CHINA.csv
+++ b/outputs/L222.SubsectorLogit_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L222.SubsectorShrwtFllt_en_CHINA.csv
+++ b/outputs/L222.SubsectorShrwtFllt_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:377911d2da430f29dc2abb03139a25221d5ac43636f467c0e8d0ead3dde4dfda
+size 5461

--- a/outputs/L222.Supplysector_absolute-cost-logit_CHINA.csv
+++ b/outputs/L222.Supplysector_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f978a864f3bd548c52b70586a8a1e8a5e5f883e06106290e7affe63a4449e74
+size 32

--- a/outputs/L222.Supplysector_en_CHINA.csv
+++ b/outputs/L222.Supplysector_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b407b3fe1595690e7a4665af9252af8f45ee8dc584650534c90c2e13573a1b89
+size 5633

--- a/outputs/L222.Supplysector_relative-cost-logit_CHINA.csv
+++ b/outputs/L222.Supplysector_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ede82d2d6356ed9226ce26afa1f893d9c21025bec404bd2698739ef3cd229bc
+size 5180

--- a/outputs/L222.TechCoef_CHINAen_CHINA.csv
+++ b/outputs/L222.TechCoef_CHINAen_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd0eb0caf186427c67c7825466b0e2942736432781ae397e798d56c9361393c5
+size 201964

--- a/outputs/L222.TechEQUIV_CHINA.csv
+++ b/outputs/L222.TechEQUIV_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2be761e7d480005647c8588d4bef7d1e52891d162d1fc141102f250441cf65e
+size 69

--- a/outputs/L222.TechInterp_CHINAen_CHINA.csv
+++ b/outputs/L222.TechInterp_CHINAen_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8099f1e053a1d0b3a66b115d4d4e5ce43947df4a7e2621877562bb8cbe77ff4f
+size 4928

--- a/outputs/L222.TechShrwt_CHINAen_CHINA.csv
+++ b/outputs/L222.TechShrwt_CHINAen_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7efcb088a29c59d695e816050dd9fdaeb333aa801329b68a9add71e9ddd5cf3
+size 152828

--- a/outputs/L222.Tech_CHINAen_CHINA.csv
+++ b/outputs/L222.Tech_CHINAen_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60b8f3ee27fc68c20a5d6fbfb6f944cdf55e33fa33ba817009ed0cb5dcc493cd
+size 6118

--- a/outputs/L223.BaseGDP_GRIDR_CHINA.csv
+++ b/outputs/L223.BaseGDP_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57b8a627952f2447753acc7b8b5b4bc87f8146f4f575d18aecb37f44e955932e
+size 154

--- a/outputs/L223.EQUIV_TABLE_CHINA.csv
+++ b/outputs/L223.EQUIV_TABLE_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3c038fc6e3145cc949c8edae24dc146744fd94a59cc5e49e05a31c83374efbc
+size 94

--- a/outputs/L223.ElecReserve_CHINA.csv
+++ b/outputs/L223.ElecReserve_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:386078fa1fdae19ccb8eeea854b6c3c6af7e4e6df521af44202a7cd6edfa302b
+size 1760

--- a/outputs/L223.InterestRate_GRIDR_CHINA.csv
+++ b/outputs/L223.InterestRate_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fb0f67ad2a29a8c511d43ada82bc0864b59486eb37a72c94c4589acad65cba1
+size 178

--- a/outputs/L223.LaborForceFillout_GRIDR_CHINA.csv
+++ b/outputs/L223.LaborForceFillout_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3629cfd916e194f9181188eff86d8c0df64039f5e8398566601900cf505192c8
+size 212

--- a/outputs/L223.Pop_GRIDR_CHINA.csv
+++ b/outputs/L223.Pop_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:566184206c494f4255c8c430fad4bf907e484ed4a3e3a3d816079ccd05a76d9f
+size 3718

--- a/outputs/L223.Production_elec_GRIDR_CHINA.csv
+++ b/outputs/L223.Production_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09f955697aa6825ccfef71e729ad78ee3138bf6ff0a932d9624dff98902fdaf1
+size 11530

--- a/outputs/L223.StubTechCapFactor_elec_CHINA.csv
+++ b/outputs/L223.StubTechCapFactor_elec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1987186efc3e3bd99c114008cfac3a3ca748c05d982427b3c8b430949beba2b0
+size 255620

--- a/outputs/L223.StubTechCapFactor_elec_solar_CHINA.csv
+++ b/outputs/L223.StubTechCapFactor_elec_solar_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d08d6e9af1a55346e3737dc1d6547d7d8d759acf35e99276bf343f53bab98632
+size 113280

--- a/outputs/L223.StubTechCapFactor_elec_wind_CHINA.csv
+++ b/outputs/L223.StubTechCapFactor_elec_wind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c17f0c9da792814affe7f12e39709e2ae2f4797bebde1865d9e17425a5ee370
+size 54628

--- a/outputs/L223.StubTechEff_elec_CHINA.csv
+++ b/outputs/L223.StubTechEff_elec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a837e0aa30f8f6783d7dc59d3677d9644c9bb7168869817f022e957a86ac5077
+size 49101

--- a/outputs/L223.StubTechFixOut_elec_CHINA.csv
+++ b/outputs/L223.StubTechFixOut_elec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:043197073b66a9716cbf5706ae82fb8cc0eb2d15179e4563e9cff395de1cb1eb
+size 6489

--- a/outputs/L223.StubTechFixOut_elec_nuclear_CHINA.csv
+++ b/outputs/L223.StubTechFixOut_elec_nuclear_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d613d1ea20b50c227033ee0102bb2533db805f21478937c649c6667ef39efc6
+size 6301

--- a/outputs/L223.StubTechFixOut_hydro_CHINA.csv
+++ b/outputs/L223.StubTechFixOut_hydro_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d331fb22d5230debf06233ab5eea0fe2096363100b842f3cb2e3ea06d1ef548
+size 33402

--- a/outputs/L223.StubTechMarket_backup_CHINA.csv
+++ b/outputs/L223.StubTechMarket_backup_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfd6d618b003b24686d03cbfcdfa7f393667b9e8961d36957e391c44f6a062b5
+size 155581

--- a/outputs/L223.StubTechMarket_elec_CHINA.csv
+++ b/outputs/L223.StubTechMarket_elec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e2839baf94b565a8c5639b89436d069d5abb9aa5de50618fa3b8c957c76fb4e
+size 1103737

--- a/outputs/L223.StubTechProd_elec_CHINA.csv
+++ b/outputs/L223.StubTechProd_elec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e59830cfe45e95931acc2191dfc38a77cdb9b4a0db04e40b4fbd5e4edac20bc9
+size 62722

--- a/outputs/L223.StubTech_elec_CHINA.csv
+++ b/outputs/L223.StubTech_elec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5010a40761b322103f438c442fe5795b93a48becb35f1b461038f3ae9efeae1
+size 29949

--- a/outputs/L223.SubsectorInterpTo_elec_CHINA.csv
+++ b/outputs/L223.SubsectorInterpTo_elec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cf69b420e1ae208aa6a565d054b488898185f5974c61fff50e3784538e76cab
+size 7482

--- a/outputs/L223.SubsectorInterp_elec_CHINA.csv
+++ b/outputs/L223.SubsectorInterp_elec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc562fb9dbbc198616998938e4cd53ae5d8eb40d76ace57129e2f47e8816c1a0
+size 21331

--- a/outputs/L223.SubsectorInterp_elec_GRIDR_CHINA.csv
+++ b/outputs/L223.SubsectorInterp_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fd93a88912b0a98e1efa39a728b6e745f790ba275b032a1563e61a85ed0d457
+size 2629

--- a/outputs/L223.SubsectorLogit_absolute-cost-logit_CHINA.csv
+++ b/outputs/L223.SubsectorLogit_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L223.SubsectorLogit_absolute-cost-logit_GRIDR_CHINA.csv
+++ b/outputs/L223.SubsectorLogit_absolute-cost-logit_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L223.SubsectorLogit_elec_CHINA.csv
+++ b/outputs/L223.SubsectorLogit_elec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:197cc1f3124c265b05687541776f55419cb5adbe8b0169e6bf160ad0c6c3bcc9
+size 10125

--- a/outputs/L223.SubsectorLogit_elec_GRIDR_CHINA.csv
+++ b/outputs/L223.SubsectorLogit_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17f11e78262daeffe5f04e338c06cbc6d2b9b1bad0072acd34cf247344bdce7a
+size 1920

--- a/outputs/L223.SubsectorLogit_relative-cost-logit_CHINA.csv
+++ b/outputs/L223.SubsectorLogit_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f994a5799a4faa5d3b0fec894306c738e54562cc87982902af40c56a130bd102
+size 13702

--- a/outputs/L223.SubsectorLogit_relative-cost-logit_GRIDR_CHINA.csv
+++ b/outputs/L223.SubsectorLogit_relative-cost-logit_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89ab0c5f8324bbe4bccaed6dcd43be313fc1b8da8de9494e0d7cfa2a849cafa0
+size 2293

--- a/outputs/L223.SubsectorShrwtFllt_elec_CHINA.csv
+++ b/outputs/L223.SubsectorShrwtFllt_elec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7961985843337dbb406c5365fe6fffeed8671f5bb63b9688eafa008247865742
+size 10989

--- a/outputs/L223.SubsectorShrwtFllt_elec_GRIDR_CHINA.csv
+++ b/outputs/L223.SubsectorShrwtFllt_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34aac7d7988437810fdc7572b0caed797a6adfb34b91328e3bfd31091b0e8ccb
+size 1879

--- a/outputs/L223.SubsectorShrwt_nuc_CHINA.csv
+++ b/outputs/L223.SubsectorShrwt_nuc_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3da69cf55dd3f80065267b237449ad783013021e55ec1679f49e66110515afa
+size 18958

--- a/outputs/L223.SubsectorShrwt_renew_CHINA.csv
+++ b/outputs/L223.SubsectorShrwt_renew_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6eeb6563aa3a6235801e44f69e41fbb41799dd8fc283422af7141fa8617f0038
+size 3589

--- a/outputs/L223.Supplysector_absolute-cost-logit_CHINA.csv
+++ b/outputs/L223.Supplysector_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f978a864f3bd548c52b70586a8a1e8a5e5f883e06106290e7affe63a4449e74
+size 32

--- a/outputs/L223.Supplysector_absolute-cost-logit_GRIDR_CHINA.csv
+++ b/outputs/L223.Supplysector_absolute-cost-logit_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f978a864f3bd548c52b70586a8a1e8a5e5f883e06106290e7affe63a4449e74
+size 32

--- a/outputs/L223.Supplysector_elec_CHINA.csv
+++ b/outputs/L223.Supplysector_elec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63554423cd5681c38dbdc0368ab98f3c4966442de8c93d5627fbc6c3d1f958d4
+size 2696

--- a/outputs/L223.Supplysector_elec_GRIDR_CHINA.csv
+++ b/outputs/L223.Supplysector_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5e55958f26110dbba15fb5922f85b8ebfc39a1224cc78af8d0c07d25e1d9637
+size 425

--- a/outputs/L223.Supplysector_relative-cost-logit_CHINA.csv
+++ b/outputs/L223.Supplysector_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61e52da7e60955b10a95bce2d3792624af8f495ea1520f82689b8ca9c5ddea8d
+size 2441

--- a/outputs/L223.Supplysector_relative-cost-logit_GRIDR_CHINA.csv
+++ b/outputs/L223.Supplysector_relative-cost-logit_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20ff400d452d5a26de3682665d492afa49245a412ee874272fb544e0d0b6660d
+size 350

--- a/outputs/L223.TechCoef_elec_GRIDR_CHINA.csv
+++ b/outputs/L223.TechCoef_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:815f100f0e51c437478c7acd57c98b079f9a6641cbcae6403c8df23c50ec7dac
+size 61956

--- a/outputs/L223.TechShrwt_elec_GRIDR_CHINA.csv
+++ b/outputs/L223.TechShrwt_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b852df6748c724a74c4b6671a6b36d7cac4529f94297938e325d708cf2c8c232
+size 51034

--- a/outputs/L2232.DeleteSupplysector_CHINAelec_CHINA.csv
+++ b/outputs/L2232.DeleteSupplysector_CHINAelec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:448894cabbef07667e332ce77c54815f344c889fcab34873872352f95869330a
+size 70

--- a/outputs/L2232.EQUIV_TABLE_CHINA.csv
+++ b/outputs/L2232.EQUIV_TABLE_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3c038fc6e3145cc949c8edae24dc146744fd94a59cc5e49e05a31c83374efbc
+size 94

--- a/outputs/L2232.ElecReserve_GRIDR_CHINA.csv
+++ b/outputs/L2232.ElecReserve_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4524257adfe9dbc160da92d2cfba394ac0ac38ef1f26b4f6d48f692509160f25
+size 329

--- a/outputs/L2232.Production_elec_gen_GRIDR_CHINA.csv
+++ b/outputs/L2232.Production_elec_gen_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d67086223609b13d076f77561ee61de11d82b3f5f7bc7e6566f196aff04ad779
+size 2970

--- a/outputs/L2232.Production_exports_CHINAelec_CHINA.csv
+++ b/outputs/L2232.Production_exports_CHINAelec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cdc7ccad893e5f93a0e412e5a11293c705d737e31eda24318bb98c41ada4fc1
+size 2996

--- a/outputs/L2232.Production_imports_GRIDR_CHINA.csv
+++ b/outputs/L2232.Production_imports_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27ce83a0d45f257aeca46e1d7eff8874ee26caf8e61c9b8a3045d2aa22949eaa
+size 2659

--- a/outputs/L2232.StubTechElecMarket_backup_CHINA.csv
+++ b/outputs/L2232.StubTechElecMarket_backup_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2070bfac68447513c759dfe8d8b435dc6394152d42a0bb77e87531de48ae7078
+size 146947

--- a/outputs/L2232.SubsectorInterp_CHINAelec_CHINA.csv
+++ b/outputs/L2232.SubsectorInterp_CHINAelec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c558dca9ae4c52b5631bb862f4a7f00a0c06c180d4b8ee7fbf62f7f18e3ddd2
+size 633

--- a/outputs/L2232.SubsectorInterp_elec_GRIDR_CHINA.csv
+++ b/outputs/L2232.SubsectorInterp_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d9ddf80ce88166535c4106413bc74edecb4cfcdffc94f1a5e5970b731f4c9e1
+size 1839

--- a/outputs/L2232.SubsectorLogit_CHINAelec_CHINA.csv
+++ b/outputs/L2232.SubsectorLogit_CHINAelec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10d1c11f7fc5e7e70aa00922cc4be53eef9938b78f74a9ebaface50e8e985064
+size 491

--- a/outputs/L2232.SubsectorLogit_absolute-cost-logit_CHINA.csv
+++ b/outputs/L2232.SubsectorLogit_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L2232.SubsectorLogit_absolute-cost-logit_GRIDR_CHINA.csv
+++ b/outputs/L2232.SubsectorLogit_absolute-cost-logit_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L2232.SubsectorLogit_elec_GRIDR_CHINA.csv
+++ b/outputs/L2232.SubsectorLogit_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7edab87a154d539fa285d69e43652d7b7f5d8b63358962d7658d3a2304c28ba8
+size 1445

--- a/outputs/L2232.SubsectorLogit_relative-cost-logit_CHINA.csv
+++ b/outputs/L2232.SubsectorLogit_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:485b2c4d2ed3e1d72f8a7d6a815b7e534f08fe2bf9cac42ef188da47f4b3a2ea
+size 540

--- a/outputs/L2232.SubsectorLogit_relative-cost-logit_GRIDR_CHINA.csv
+++ b/outputs/L2232.SubsectorLogit_relative-cost-logit_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:315d43dd19f3278be981ad3ae302413b4a09bdb4a7ee9edbd26e58ab709ba6f6
+size 1638

--- a/outputs/L2232.SubsectorShrwtFllt_CHINAelec_CHINA.csv
+++ b/outputs/L2232.SubsectorShrwtFllt_CHINAelec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73aa18533c882a2eca2f18b4f0beb62fae294e2928c37b3ce676307db1f5cf07
+size 477

--- a/outputs/L2232.SubsectorShrwtFllt_elec_GRIDR_CHINA.csv
+++ b/outputs/L2232.SubsectorShrwtFllt_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b231a2bbb277cd4efc227a8da568e2fa5adb2236278191b7f850a12c9596336
+size 1419

--- a/outputs/L2232.Supplysector_CHINAelec_CHINA.csv
+++ b/outputs/L2232.Supplysector_CHINAelec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1441906950826297329b4ca4d852168265ffdb3e64080be220dce6eaa801fd5b
+size 137

--- a/outputs/L2232.Supplysector_absolute-cost-logit_CHINA.csv
+++ b/outputs/L2232.Supplysector_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f978a864f3bd548c52b70586a8a1e8a5e5f883e06106290e7affe63a4449e74
+size 32

--- a/outputs/L2232.Supplysector_absolute-cost-logit_GRIDR_CHINA.csv
+++ b/outputs/L2232.Supplysector_absolute-cost-logit_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f978a864f3bd548c52b70586a8a1e8a5e5f883e06106290e7affe63a4449e74
+size 32

--- a/outputs/L2232.Supplysector_elec_GRIDR_CHINA.csv
+++ b/outputs/L2232.Supplysector_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6248673bcf86937c3f452ce5d30d985c129f9597ae42f868e4bcfa42d48e7e1
+size 1355

--- a/outputs/L2232.Supplysector_relative-cost-logit_CHINA.csv
+++ b/outputs/L2232.Supplysector_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:070e468f1f022eae6210dfa98ba80eafeba966cbf2c8318392698a630bf06520
+size 77

--- a/outputs/L2232.Supplysector_relative-cost-logit_GRIDR_CHINA.csv
+++ b/outputs/L2232.Supplysector_relative-cost-logit_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3e61c74a30cfee999659b25b4cd4f62a56615c990d7b6342cd85231ba745f60
+size 1244

--- a/outputs/L2232.TechCoef_CHINAelec_CHINA.csv
+++ b/outputs/L2232.TechCoef_CHINAelec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a741ad7388267f007f1a71956ceeb9ce0886099ec899c69cfbb3183b777edbc
+size 20024

--- a/outputs/L2232.TechCoef_elec_GRIDR_CHINA.csv
+++ b/outputs/L2232.TechCoef_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c954d8a89de50496577d08c19251b75aa21ab0212b99512f3f1629b86653ec0
+size 34544

--- a/outputs/L2232.TechCoef_elecownuse_GRIDR_CHINA.csv
+++ b/outputs/L2232.TechCoef_elecownuse_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce70debecd9aac1ddb4ce889d0a973000741db04648c83d1034be4656e73dbad
+size 19088

--- a/outputs/L2232.TechShrwt_CHINAelec_CHINA.csv
+++ b/outputs/L2232.TechShrwt_CHINAelec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a64ddc3362b043556f4c75898a5a134571a6f4d62f1fdc0b341594b2280db44d
+size 16968

--- a/outputs/L2232.TechShrwt_elec_GRIDR_CHINA.csv
+++ b/outputs/L2232.TechShrwt_elec_GRIDR_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8dd552ddc038fbd3f36bfae43fae3f64c89ecc4382876dace5a807dac334152
+size 38472

--- a/outputs/L225.DeleteSubsector_h2_CHINA.csv
+++ b/outputs/L225.DeleteSubsector_h2_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81add917b7033efd3d3a0d4af20d1977d75ae8aa0b52feb6232d5194059b857e
+size 115

--- a/outputs/L226.Ccoef_CHINA.csv
+++ b/outputs/L226.Ccoef_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0e7fe0d0c18c7159c83228074c6c4ffaba75bfa589f69afec54416c2f219a4e
+size 5353

--- a/outputs/L226.DeleteSupplysector_CHINAelec_CHINA.csv
+++ b/outputs/L226.DeleteSupplysector_CHINAelec_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17e458914d38d5d3034e5b5b8c3e9f8db5ce77fdc093211f884d991538a6bbee
+size 81

--- a/outputs/L226.EQUIV_TABLE_CHINA.csv
+++ b/outputs/L226.EQUIV_TABLE_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3c038fc6e3145cc949c8edae24dc146744fd94a59cc5e49e05a31c83374efbc
+size 94

--- a/outputs/L226.EQUIV_TABLE_en_CHINA.csv
+++ b/outputs/L226.EQUIV_TABLE_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3c038fc6e3145cc949c8edae24dc146744fd94a59cc5e49e05a31c83374efbc
+size 94

--- a/outputs/L226.SubsectorInterp_electd_CHINA.csv
+++ b/outputs/L226.SubsectorInterp_electd_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:554fe0c8049177ccb907cdc9f24c4beb4c054900865c58e25f26aa9234ab7cb4
+size 6021

--- a/outputs/L226.SubsectorLogit_absolute-cost-logit_CHINA.csv
+++ b/outputs/L226.SubsectorLogit_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L226.SubsectorLogit_absolute-cost-logit_en_CHINA.csv
+++ b/outputs/L226.SubsectorLogit_absolute-cost-logit_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L226.SubsectorLogit_electd_CHINA.csv
+++ b/outputs/L226.SubsectorLogit_electd_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72d7e860e3f3705fa405ef7940ba6396e60d7c88097f2bfb8e5695545b687ccb
+size 3827

--- a/outputs/L226.SubsectorLogit_en_CHINA.csv
+++ b/outputs/L226.SubsectorLogit_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f603490a4b70a7bfb8e9ab68416a76b70dacc13adb147416335fa3e8deb2aa73
+size 9503

--- a/outputs/L226.SubsectorLogit_relative-cost-logit_CHINA.csv
+++ b/outputs/L226.SubsectorLogit_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7d6b429ee48daf79c1038e2f64c597d31af2b6255a2aca5ac8ed33f07952854
+size 4992

--- a/outputs/L226.SubsectorLogit_relative-cost-logit_en_CHINA.csv
+++ b/outputs/L226.SubsectorLogit_relative-cost-logit_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:135c1faf1930eb2a2319d78e975f5ce9f4df78513df425a265ddf54ed40e6513
+size 11856

--- a/outputs/L226.SubsectorShrwtFllt_electd_CHINA.csv
+++ b/outputs/L226.SubsectorShrwtFllt_electd_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af979ac05347a34c1aa99c88c910169d514f97951a6fba9d5555e2a1da901342
+size 3720

--- a/outputs/L226.SubsectorShrwtFllt_en_CHINA.csv
+++ b/outputs/L226.SubsectorShrwtFllt_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e18463fc7ffaae5f161c802aa1d2d6cd9bf67a88bbe085245bfad8126aed991
+size 9297

--- a/outputs/L226.Supplysector_absolute-cost-logit_CHINA.csv
+++ b/outputs/L226.Supplysector_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f978a864f3bd548c52b70586a8a1e8a5e5f883e06106290e7affe63a4449e74
+size 32

--- a/outputs/L226.Supplysector_absolute-cost-logit_en_CHINA.csv
+++ b/outputs/L226.Supplysector_absolute-cost-logit_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f978a864f3bd548c52b70586a8a1e8a5e5f883e06106290e7affe63a4449e74
+size 32

--- a/outputs/L226.Supplysector_electd_CHINA.csv
+++ b/outputs/L226.Supplysector_electd_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a149389c3e10a2e7424d03df4f4a15cd8428ff601eeeae9af9533d20ac7bb22
+size 4049

--- a/outputs/L226.Supplysector_en_CHINA.csv
+++ b/outputs/L226.Supplysector_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3ecae0f812a4f913f0527cdf480912382f8114c3214f38124203c9a57d5eb02
+size 8966

--- a/outputs/L226.Supplysector_relative-cost-logit_CHINA.csv
+++ b/outputs/L226.Supplysector_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ea96a4c955591b3031676b3263b95aa284abdf2e0bfd28f708d81c950ea344f
+size 3695

--- a/outputs/L226.Supplysector_relative-cost-logit_en_CHINA.csv
+++ b/outputs/L226.Supplysector_relative-cost-logit_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60f4960b3583af48a71488759fdc686239ddfc31e7b82d6bea33e460e5eb4040
+size 8315

--- a/outputs/L226.TechCoef_electd_CHINA.csv
+++ b/outputs/L226.TechCoef_electd_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:663ea866e5abc0cf7eae222e99d8fff8a7230d88fca4c7cec2b42d357c936e59
+size 231323

--- a/outputs/L226.TechCoef_en_CHINA.csv
+++ b/outputs/L226.TechCoef_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57ebb641f9328de407dae1072489db4ace1c79871be29fcccf9db56d54f1a032
+size 384872

--- a/outputs/L226.TechCost_electd_CHINA.csv
+++ b/outputs/L226.TechCost_electd_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b44f8fa0484657780adad079662760ee283536c65cd69850bfee1677f291e6c6
+size 143039

--- a/outputs/L226.TechCost_en_CHINA.csv
+++ b/outputs/L226.TechCost_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b85f76eed42bb7cc4551d5fb89f089d86141ecc23ba75ba866e45af0aa1aa14
+size 416345

--- a/outputs/L226.TechShrwt_electd_CHINA.csv
+++ b/outputs/L226.TechShrwt_electd_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a96f4b683daafb65b9352386af1a04b0409974851fba78236d5fa8714181956
+size 108960

--- a/outputs/L226.TechShrwt_en_CHINA.csv
+++ b/outputs/L226.TechShrwt_en_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68ad4b49296fc39ce00e0d22248bd495d93d0dcbaa7f917d4a57a200935c9a88
+size 281022

--- a/outputs/L232.BaseService_ind_CHINA.csv
+++ b/outputs/L232.BaseService_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba10e1411bc7806717e28cdbb39c9cb26fda4bcfc5760c173957b91778576bcb
+size 3502

--- a/outputs/L232.DeleteFinalDemand_CHINAind_CHINA.csv
+++ b/outputs/L232.DeleteFinalDemand_CHINAind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:147b779a49fa0fc071310a0f4b78ba39c14a53aba52aaa80621f36e9539d2b3e
+size 44

--- a/outputs/L232.DeleteSubsector_ind_CHINA.csv
+++ b/outputs/L232.DeleteSubsector_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:437294ee70210c33de44bd6408007c7121e451ae891426b901d51c2c972a5c15
+size 25617

--- a/outputs/L232.DeleteSupplysector_CHINAind_CHINA.csv
+++ b/outputs/L232.DeleteSupplysector_CHINAind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f7b6d99371c6f4093fae2f295f1954495d9b9206a22c3f4a0e95e51cf36a9ac
+size 95

--- a/outputs/L232.EQUIV_TABLE_CHINA.csv
+++ b/outputs/L232.EQUIV_TABLE_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3c038fc6e3145cc949c8edae24dc146744fd94a59cc5e49e05a31c83374efbc
+size 94

--- a/outputs/L232.FinalEnergyKeyword_ind_CHINA.csv
+++ b/outputs/L232.FinalEnergyKeyword_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fefd0d95842c10a227d06c790c717193526376ac5052d11e116ba575cb183c9
+size 2344

--- a/outputs/L232.FuelPrefElast_indenergy_CHINA.csv
+++ b/outputs/L232.FuelPrefElast_indenergy_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9fff4fb712bd1f33241b4ca2f22325f55eaa25aae6116bb3a548f4ad644ae58
+size 1350

--- a/outputs/L232.IncomeElasticity_ind_gcam3_CHINA.csv
+++ b/outputs/L232.IncomeElasticity_ind_gcam3_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ce1172010a9d52cea348a490ffce40f1b413479761d9392c208bcb3760638f5
+size 14307

--- a/outputs/L232.PerCapitaBased_ind_CHINA.csv
+++ b/outputs/L232.PerCapitaBased_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59374d5e8976ff0cb43591101c5beef96e4ee95a312d9a83dffe29044c1c2b1b
+size 538

--- a/outputs/L232.PriceElasticity_ind_CHINA.csv
+++ b/outputs/L232.PriceElasticity_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f0e6c7076c256e9a94188598b37eb439d8b492a38b3b9256641194ea0482a83
+size 12524

--- a/outputs/L232.StubTechCalInput_indenergy_CHINA.csv
+++ b/outputs/L232.StubTechCalInput_indenergy_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8619a0defacbf1812c2c60a25a4fc3e5646b64825462484d5db052bf2ebb958
+size 104808

--- a/outputs/L232.StubTechCalInput_indfeed_CHINA.csv
+++ b/outputs/L232.StubTechCalInput_indfeed_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98e378a934640b09e038cdce24418736fd8dbf0be7d8712718b6a07fbd9543ec
+size 28555

--- a/outputs/L232.StubTechCoef_industry_CHINA.csv
+++ b/outputs/L232.StubTechCoef_industry_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b35e009136fcf057f4aa7f9208caa63a9dbef010b44cc2775854ad1371d9ee20
+size 96715

--- a/outputs/L232.StubTechInterp_ind_CHINA.csv
+++ b/outputs/L232.StubTechInterp_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba76774ce2bfa33d70153fbb8cf403644486f280a7d5c212e82305412fd99aa9
+size 19765

--- a/outputs/L232.StubTechMarket_ind_CHINA.csv
+++ b/outputs/L232.StubTechMarket_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0647450d6835108628d65837f0f358203915302df477a50bf0447979430fd006
+size 781261

--- a/outputs/L232.StubTechProd_industry_CHINA.csv
+++ b/outputs/L232.StubTechProd_industry_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1bd93486b20adb6dba647a87008627ed76aaf14d52d93cec74830d45e3775bd2
+size 6925

--- a/outputs/L232.StubTechSecMarket_ind_CHINA.csv
+++ b/outputs/L232.StubTechSecMarket_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ed230205a85a330e31a290ee4ae9fa20007806b6c66d7e54dcb6b5d72ae4019
+size 312305

--- a/outputs/L232.StubTech_ind_CHINA.csv
+++ b/outputs/L232.StubTech_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56e0fe7aea77eb8950978cd1fc7628392662a9b41b4af034e23ffeceb373fed6
+size 23840

--- a/outputs/L232.SubsectorInterp_ind_CHINA.csv
+++ b/outputs/L232.SubsectorInterp_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40411875ed0bf7128846e87962c5bf88e2c298818143d010c1f1f32b529adf01
+size 21333

--- a/outputs/L232.SubsectorLogit_absolute-cost-logit_CHINA.csv
+++ b/outputs/L232.SubsectorLogit_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L232.SubsectorLogit_ind_CHINA.csv
+++ b/outputs/L232.SubsectorLogit_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75fe1f4268478a1ffd658411c72e1937103519fc2d922c2c273529345597380a
+size 15344

--- a/outputs/L232.SubsectorLogit_relative-cost-logit_CHINA.csv
+++ b/outputs/L232.SubsectorLogit_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d578b1fe283cc6c596a2b4ac13d3ebc5ceeb2370b45aaac008f8f31bdaf1267f
+size 19677

--- a/outputs/L232.SubsectorShrwtFllt_ind_CHINA.csv
+++ b/outputs/L232.SubsectorShrwtFllt_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb45baf7691ba55b0dab1e7472c95050bdb8632dfafce0ddf3d2ced625c53a1a
+size 16458

--- a/outputs/L232.Supplysector_absolute-cost-logit_CHINA.csv
+++ b/outputs/L232.Supplysector_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f978a864f3bd548c52b70586a8a1e8a5e5f883e06106290e7affe63a4449e74
+size 32

--- a/outputs/L232.Supplysector_ind_CHINA.csv
+++ b/outputs/L232.Supplysector_ind_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6818c3098c2deeedb533c11bae61d224bc02fa05aae4bd613701d7ab28c1f459
+size 4511

--- a/outputs/L232.Supplysector_relative-cost-logit_CHINA.csv
+++ b/outputs/L232.Supplysector_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68012dfa610c1722dc6e6dcebd389fbb02fdef46fcca1149fbc471723f0f1f07
+size 4157

--- a/outputs/L2321.BaseService_cement_CHINA.csv
+++ b/outputs/L2321.BaseService_cement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:483f7062a131f2dba3f96300cba7074e0392c11ac9d31fd7ba53d07fb14513e9
+size 3329

--- a/outputs/L2321.DeleteFinalDemand_CHINAcement_CHINA.csv
+++ b/outputs/L2321.DeleteFinalDemand_CHINAcement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21979eaa1d27642f4e31dadc7ae7e3945d3caed39d8492ee5dc4a34569af44e1
+size 42

--- a/outputs/L2321.DeleteSupplysector_CHINAcement_CHINA.csv
+++ b/outputs/L2321.DeleteSupplysector_CHINAcement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e7a5196eae74df247543a769bc45c1c330057e799b96e6155668ee8e4fd77d6
+size 62

--- a/outputs/L2321.EQUIV_TABLE_CHINA.csv
+++ b/outputs/L2321.EQUIV_TABLE_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3c038fc6e3145cc949c8edae24dc146744fd94a59cc5e49e05a31c83374efbc
+size 94

--- a/outputs/L2321.FinalEnergyKeyword_cement_CHINA.csv
+++ b/outputs/L2321.FinalEnergyKeyword_cement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c038a072f7bbbd1b453775ff3d4e786ad6570f5a1b2a92db7b50c8bdb428b8e
+size 1677

--- a/outputs/L2321.IncomeElasticity_cement_gcam3_CHINA.csv
+++ b/outputs/L2321.IncomeElasticity_cement_gcam3_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01d9c31dd8366e38f3f06a0275e30d6b68391464d191f5283ca7d3651cb9b284
+size 12885

--- a/outputs/L2321.PerCapitaBased_cement_CHINA.csv
+++ b/outputs/L2321.PerCapitaBased_cement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:451d24691cd0a5872813519319b2a397744ce7e8e9a9742a687c11e4dc5c0cbd
+size 446

--- a/outputs/L2321.PriceElasticity_cement_CHINA.csv
+++ b/outputs/L2321.PriceElasticity_cement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eead569adc7ba998c4d78a21b8684757d6b7d4b59f8eed631f9610c5f44ef1da
+size 11768

--- a/outputs/L2321.StubTechCalInput_cement_heat_CHINA.csv
+++ b/outputs/L2321.StubTechCalInput_cement_heat_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b384ac29a4bb65cff8eb0623f22af4c16e1c01310317551e31ac101fa516ac1e
+size 39286

--- a/outputs/L2321.StubTechCoef_cement_CHINA.csv
+++ b/outputs/L2321.StubTechCoef_cement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9cf03be31de013b9357a3d1013ba0b3b1fdac160dd3db2d9cc7aa1a6f40ce18
+size 231171

--- a/outputs/L2321.StubTechMarket_cement_CHINA.csv
+++ b/outputs/L2321.StubTechMarket_cement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bb414001a3e0b54f339b8af9b8a24090a04483c05df57a63a6908b2bd8381cd
+size 184907

--- a/outputs/L2321.StubTechProd_cement_CHINA.csv
+++ b/outputs/L2321.StubTechProd_cement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c960da85cc642b49f6f217f70f8d115763f9ae01878072fe3ed331754d3870d1
+size 6256

--- a/outputs/L2321.StubTech_cement_CHINA.csv
+++ b/outputs/L2321.StubTech_cement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c48e39c52a07c673ef48492de097f53b11e2aa6a450a31e5b194ce88ef6e576c
+size 6743

--- a/outputs/L2321.SubsectorInterp_cement_CHINA.csv
+++ b/outputs/L2321.SubsectorInterp_cement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c731629ee7eb8542ba4b464995840390a3a6a3bce9240fa489e527dc3254cd4
+size 9133

--- a/outputs/L2321.SubsectorLogit_absolute-cost-logit_CHINA.csv
+++ b/outputs/L2321.SubsectorLogit_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L2321.SubsectorLogit_cement_CHINA.csv
+++ b/outputs/L2321.SubsectorLogit_cement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9aa7c7a67ef32a1c50c0d5007a2cb6842ff18bde60a5fb0b9b84249dc87dd59
+size 5893

--- a/outputs/L2321.SubsectorLogit_relative-cost-logit_CHINA.csv
+++ b/outputs/L2321.SubsectorLogit_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02231ffc2caaf23bac0c75b796d0e92c37e6fd24a4cf1ead962d2e4dfed3a77a
+size 7699

--- a/outputs/L2321.SubsectorShrwtFllt_cement_CHINA.csv
+++ b/outputs/L2321.SubsectorShrwtFllt_cement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2497bc902462812cd1453c0bdaf0d17472370e020ae2ccf26b4d77e4e065eddf
+size 5699

--- a/outputs/L2321.Supplysector_absolute-cost-logit_CHINA.csv
+++ b/outputs/L2321.Supplysector_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f978a864f3bd548c52b70586a8a1e8a5e5f883e06106290e7affe63a4449e74
+size 32

--- a/outputs/L2321.Supplysector_cement_CHINA.csv
+++ b/outputs/L2321.Supplysector_cement_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:246114e04b2fd45042d442f60e13c7a762d5e0b9a170304e62e29e740cb4555c
+size 2786

--- a/outputs/L2321.Supplysector_relative-cost-logit_CHINA.csv
+++ b/outputs/L2321.Supplysector_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4712aaf4d6b4016d3aedfc8e4110ca4c3869606365f1ec824dc9addd56c580df
+size 2357

--- a/outputs/L2322.DeleteSubsector_CHINAFert_CHINA.csv
+++ b/outputs/L2322.DeleteSubsector_CHINAFert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29897191c0fc2d6b3b0203a0fbf85cdb617c2d03ac7f9e6e4ffedc715e89e88c
+size 116

--- a/outputs/L2322.EQUIV_TABLE_CHINA.csv
+++ b/outputs/L2322.EQUIV_TABLE_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3c038fc6e3145cc949c8edae24dc146744fd94a59cc5e49e05a31c83374efbc
+size 94

--- a/outputs/L2322.FinalEnergyKeyword_CHINAFert_CHINA.csv
+++ b/outputs/L2322.FinalEnergyKeyword_CHINAFert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a68ea776e4c6978a22700216ce655dd02beb4125d14d7036b259bd3de69943f
+size 59

--- a/outputs/L2322.FinalEnergyKeyword_Fert_CHINA.csv
+++ b/outputs/L2322.FinalEnergyKeyword_Fert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:164aecf386e116b66a9a84081f56196bc5a84b6493b6dfaa6427965a15573256
+size 814

--- a/outputs/L2322.Production_CHINAFert_CHINA.csv
+++ b/outputs/L2322.Production_CHINAFert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63458031ccc7c0bc37b43458b0dc956f6b021e5a4e68ba607a383925a285a03a
+size 9221

--- a/outputs/L2322.StubTechCoef_Fert_CHINA.csv
+++ b/outputs/L2322.StubTechCoef_Fert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c670f25ba02aa21c8061e55267bcc235f6844782a732fa988caa7a6efc62eb4
+size 24937

--- a/outputs/L2322.StubTechMarket_Fert_CHINA.csv
+++ b/outputs/L2322.StubTechMarket_Fert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f336f147606ac528ceabe8904891c7be5386783d81afd3aea5afdf648b6fb26
+size 188845

--- a/outputs/L2322.StubTechProd_Fert_CHINA.csv
+++ b/outputs/L2322.StubTechProd_Fert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b1e740dec4cdbea1d012c2db619699eaecbb2c96b83dadcdc4cb6f3d90613a0
+size 20834

--- a/outputs/L2322.StubTech_Fert_CHINA.csv
+++ b/outputs/L2322.StubTech_Fert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:223d41f1c594305ad5c94bc755afaa0f77e42c6a64f05e4da0fb2b32ab6bcaaf
+size 4877

--- a/outputs/L2322.SubsectorInterp_CHINAFert_CHINA.csv
+++ b/outputs/L2322.SubsectorInterp_CHINAFert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:392bf1090af8fbc656c0541c91fb9f5668a6d35016dac062ed6397d2189acdef
+size 2031

--- a/outputs/L2322.SubsectorInterp_Fert_CHINA.csv
+++ b/outputs/L2322.SubsectorInterp_Fert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b1ca37fe0fdc9f6c2c3e2cbb62e101e8ebbaf012c831d3b93eb774f801cfbe3
+size 6891

--- a/outputs/L2322.SubsectorLogit_CHINAFert_CHINA.csv
+++ b/outputs/L2322.SubsectorLogit_CHINAFert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21213fe03b54f71ab2ed488632ee13bd8be6cf041e964fcbb79185a34cdaff96
+size 1385

--- a/outputs/L2322.SubsectorLogit_Fert_CHINA.csv
+++ b/outputs/L2322.SubsectorLogit_Fert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf70f6cfd2efd98c0f77d4eb9983e5cd4f1e9c8490eeaa7bc55ad46f362abc24
+size 3155

--- a/outputs/L2322.SubsectorLogit_absolute-cost-logit_CHINA.csv
+++ b/outputs/L2322.SubsectorLogit_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L2322.SubsectorLogit_absolute-cost-logit_CHINAFert_CHINA.csv
+++ b/outputs/L2322.SubsectorLogit_absolute-cost-logit_CHINAFert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L2322.SubsectorLogit_relative-cost-logit_CHINA.csv
+++ b/outputs/L2322.SubsectorLogit_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27a0dbcc716725572d9fbe29670f3063d40425f031e8891453f73098f0216399
+size 4122

--- a/outputs/L2322.SubsectorLogit_relative-cost-logit_CHINAFert_CHINA.csv
+++ b/outputs/L2322.SubsectorLogit_relative-cost-logit_CHINAFert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e76af992bb89b4ad0ab24394ec47327f34209b0f2c4e42e18d5a6c9a1f9d0c44
+size 1722

--- a/outputs/L2322.SubsectorShrwtFllt_CHINAFert_CHINA.csv
+++ b/outputs/L2322.SubsectorShrwtFllt_CHINAFert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f4c1b61b3fa2bdec69af57bade871648b08f09c035fc8d80525dcadf348c5ec
+size 1347

--- a/outputs/L2322.SubsectorShrwtFllt_Fert_CHINA.csv
+++ b/outputs/L2322.SubsectorShrwtFllt_Fert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04a8dadbf0f030e373883240822f56e2b0e74c2db1fe055b6042df0cee6bacb7
+size 4167

--- a/outputs/L2322.Supplysector_Fert_CHINA.csv
+++ b/outputs/L2322.Supplysector_Fert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:329ae2b12cfb1cdd805dc327a58b4a9ce00323ad1f9eb9d9cc81b84e78240193
+size 1379

--- a/outputs/L2322.Supplysector_absolute-cost-logit_CHINA.csv
+++ b/outputs/L2322.Supplysector_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f978a864f3bd548c52b70586a8a1e8a5e5f883e06106290e7affe63a4449e74
+size 32

--- a/outputs/L2322.Supplysector_relative-cost-logit_CHINA.csv
+++ b/outputs/L2322.Supplysector_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6fab8f76bba7c64af32eab7a696269f3d0f0729561d5d905ab299804856fba01
+size 1142

--- a/outputs/L2322.TechCoef_CHINAFert_CHINA.csv
+++ b/outputs/L2322.TechCoef_CHINAFert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cacbd8737d78947ed8c48c51684fed697b8b9b1c8c029fc1d5848c8d23c79a1
+size 49592

--- a/outputs/L2322.TechShrwt_CHINAFert_CHINA.csv
+++ b/outputs/L2322.TechShrwt_CHINAFert_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0606751afd174f06422ac2b8179953672c6a747f91ec02daaa7f31c2c3d0c4a
+size 39000

--- a/outputs/L244.DeleteConsumer_CHINAbld_CHINA.csv
+++ b/outputs/L244.DeleteConsumer_CHINAbld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5dd7dd8e1cd15123541656fbfd7028f2c1c42eff5449defd4929f1b917a7fa2
+size 47

--- a/outputs/L244.DeleteSupplysector_CHINAbld_CHINA.csv
+++ b/outputs/L244.DeleteSupplysector_CHINAbld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8bd8668419f2317d035ad454f357776594a3d966dc6b36a29ac74604a410b72
+size 142

--- a/outputs/L244.DemandFunction_flsp_CHINA.csv
+++ b/outputs/L244.DemandFunction_flsp_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aeaef68feabf2a5398a59c2a20d29856f5c18438247757c0f2b51b4ccf173202
+size 4138

--- a/outputs/L244.DemandFunction_serv_CHINA.csv
+++ b/outputs/L244.DemandFunction_serv_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7751e2449ee092d71d056fc862f6e3b639133d83253b61dddb783af734321a0
+size 6798

--- a/outputs/L244.EQUIV_TABLE_CHINA.csv
+++ b/outputs/L244.EQUIV_TABLE_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3c038fc6e3145cc949c8edae24dc146744fd94a59cc5e49e05a31c83374efbc
+size 94

--- a/outputs/L244.FinalEnergyKeyword_bld_CHINA.csv
+++ b/outputs/L244.FinalEnergyKeyword_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef848c6e3cd04b581fe48cf2e4af09d78b18d6d0444f7097503caa9eb89df639
+size 16600

--- a/outputs/L244.Floorspace_CHINA.csv
+++ b/outputs/L244.Floorspace_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:982b85bc1b58d255e4a67a667405b4e0d25620a29ee6973e9bf0e052cd9247eb
+size 19750

--- a/outputs/L244.FuelPrefElast_bld_CHINA.csv
+++ b/outputs/L244.FuelPrefElast_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:feaf13ee9f6b24f4d8e3a5207c713ab7fb735f64c22780783998f23e57667fd8
+size 57681

--- a/outputs/L244.GenericBaseService_CHINA.csv
+++ b/outputs/L244.GenericBaseService_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:945a455c2b315ae307b974c8ac8afe71f85b844eac8cdf0974761844be857990
+size 92994

--- a/outputs/L244.GenericServiceSatiation_CHINA.csv
+++ b/outputs/L244.GenericServiceSatiation_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76d86ed3be17c0b49800abb02e74c7017b6e75c71ca2ad3329ee33e0bf675df8
+size 24472

--- a/outputs/L244.GlobalTechCost_bld_CHINA.csv
+++ b/outputs/L244.GlobalTechCost_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3088fe01327755d08ec0f4c59a5a8e22bbedcad3c202ae52acd2200ecd6978d5
+size 63973

--- a/outputs/L244.GlobalTechEff_bld_CHINA.csv
+++ b/outputs/L244.GlobalTechEff_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e994a75b099dfbdf58fbb3b793a845dd550219e35bd197813775841831eea59
+size 65341

--- a/outputs/L244.GlobalTechIntGainOutputRatio_CHINA.csv
+++ b/outputs/L244.GlobalTechIntGainOutputRatio_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aa9ffbe50d854ad9da794e3a8b3c0df953759c61c4db724abbb78bc3160ed8c
+size 43910

--- a/outputs/L244.GlobalTechSCurve_bld_CHINA.csv
+++ b/outputs/L244.GlobalTechSCurve_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1881d2e0e3899578b174a81fe18e97d013620874bfee5ee65b148bf02b8427f8
+size 29893

--- a/outputs/L244.GlobalTechShrwt_bld_CHINA.csv
+++ b/outputs/L244.GlobalTechShrwt_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb63c8ecd662b8c58d99c00cf95ec9d2de410b37eca5971f5df194d38ee282b8
+size 49139

--- a/outputs/L244.Intgains_scalar_CHINA.csv
+++ b/outputs/L244.Intgains_scalar_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b92a02df4654a4dc5c3da63e1b79cb0ee18cdef627b414ae0c48752b64beb0f4
+size 12810

--- a/outputs/L244.PriceExp_IntGains_CHINA.csv
+++ b/outputs/L244.PriceExp_IntGains_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:299f6ea2cb9df1d3211f9faec3e8d981200655242bbafcb3ec1d42cd5ca4f42d
+size 9311

--- a/outputs/L244.Satiation_flsp_CHINA.csv
+++ b/outputs/L244.Satiation_flsp_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2112b5276b2cba4ee01317f1312912b3bc7128197aa88e292f1843c85a3a3a44
+size 5497

--- a/outputs/L244.ShellConductance_bld_CHINA.csv
+++ b/outputs/L244.ShellConductance_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17fa67693acff92dc74fb5bff0e75f9c849995306aeb1799e22287b588e2afe5
+size 134881

--- a/outputs/L244.StubTechCalInput_bld_CHINA.csv
+++ b/outputs/L244.StubTechCalInput_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a654440c81e428ea33bb7b918af1a410d184b9591a3fb7c0210e601eeadb0d7
+size 471394

--- a/outputs/L244.StubTechMarket_bld_CHINA.csv
+++ b/outputs/L244.StubTechMarket_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc12c87fff299c676712c7e930a58af03210eb717d61adf586ad5344e5bb274c
+size 2207851

--- a/outputs/L244.StubTech_bld_CHINA.csv
+++ b/outputs/L244.StubTech_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:955c018fc000997ee896cbbe28c3e845bdbe0eaa5f54601463f2fbe4614438b3
+size 68390

--- a/outputs/L244.SubregionalShares_CHINA.csv
+++ b/outputs/L244.SubregionalShares_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cbda0b7551f704f76ec2313c25dadf3850ff0f27d8ea693b4afd2c9c74931e0
+size 2849

--- a/outputs/L244.SubsectorInterp_bld_CHINA.csv
+++ b/outputs/L244.SubsectorInterp_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1af44cc08d2c803ebb6d2443c3f28aa1a721c965d17d108f7bbfc1eca0e66e9e
+size 84594

--- a/outputs/L244.SubsectorLogit_absolute-cost-logit_CHINA.csv
+++ b/outputs/L244.SubsectorLogit_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L244.SubsectorLogit_bld_CHINA.csv
+++ b/outputs/L244.SubsectorLogit_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5573d7daa44c4f57b8b52e07dfbe0de80122327c8a150cab8e4cf270473ab2c
+size 56858

--- a/outputs/L244.SubsectorLogit_relative-cost-logit_CHINA.csv
+++ b/outputs/L244.SubsectorLogit_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfdd88e5de989d617bfbfd73921668a225ef7565383a8f3158e3a5d4a103787d
+size 72675

--- a/outputs/L244.SubsectorShrwtFllt_bld_CHINA.csv
+++ b/outputs/L244.SubsectorShrwtFllt_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56a3a8442c0f374e30acdef955cfd7f805fd36e655b6d25ee0690462e8ce655c
+size 56817

--- a/outputs/L244.Supplysector_absolute-cost-logit_CHINA.csv
+++ b/outputs/L244.Supplysector_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f978a864f3bd548c52b70586a8a1e8a5e5f883e06106290e7affe63a4449e74
+size 32

--- a/outputs/L244.Supplysector_bld_CHINA.csv
+++ b/outputs/L244.Supplysector_bld_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:514a459bdefa42c5b23cfbe18a87438d59a17154911cff1af39535e5740d89e5
+size 23585

--- a/outputs/L244.Supplysector_relative-cost-logit_CHINA.csv
+++ b/outputs/L244.Supplysector_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e1ce844678f8261cac35843ada780e525d27f99cfcf3dead1da7691842a578f
+size 22043

--- a/outputs/L244.ThermalBaseService_CHINA.csv
+++ b/outputs/L244.ThermalBaseService_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a8f7f61349336cb63f6484bf1fec648393ddc3d92890e8391e54a80c3aa21ba
+size 58510

--- a/outputs/L244.ThermalServiceSatiation_CHINA.csv
+++ b/outputs/L244.ThermalServiceSatiation_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fecf8b2ae897c2fd2117999d79aed075390bd41072a840360d01afe403103158
+size 15341

--- a/outputs/L254.BaseService_trn_CHINA.csv
+++ b/outputs/L254.BaseService_trn_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c90ccd4f1853d09bc1814cd583fca6dca3f2d144edd63fcf3f47b5f8ea632800
+size 15844

--- a/outputs/L254.DeleteFinalDemand_CHINAtrn_CHINA.csv
+++ b/outputs/L254.DeleteFinalDemand_CHINAtrn_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61a559a534bd592193b5fc567fab78ab8508200885a7c0de973a1b01ffd7d42f
+size 113

--- a/outputs/L254.DeleteSupplysector_CHINAtrn_CHINA.csv
+++ b/outputs/L254.DeleteSupplysector_CHINAtrn_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:659a0016b0b0c5f963cc6723c7f6362256b15b7c49161181cf2a54c1c5772955
+size 257

--- a/outputs/L254.EQUIV_TABLE_CHINA.csv
+++ b/outputs/L254.EQUIV_TABLE_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3c038fc6e3145cc949c8edae24dc146744fd94a59cc5e49e05a31c83374efbc
+size 94

--- a/outputs/L254.FinalEnergyKeyword_trn_CHINA.csv
+++ b/outputs/L254.FinalEnergyKeyword_trn_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6786ac82728ab474e4f19fdabb44aecd36f322ae7cd70bd2574317e26a60ed58
+size 11782

--- a/outputs/L254.IncomeElasticity_trn_CHINA.csv
+++ b/outputs/L254.IncomeElasticity_trn_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:700cccecc856686b95e9eaca1430d8ecf301044f3f6be5c7ae3f3350f19ba69d
+size 63015

--- a/outputs/L254.PerCapitaBased_trn_CHINA.csv
+++ b/outputs/L254.PerCapitaBased_trn_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0adbe011f31c979976d769781328a6c8944a22b06c7fa43a0f89909391448646
+size 2716

--- a/outputs/L254.PriceElasticity_trn_CHINA.csv
+++ b/outputs/L254.PriceElasticity_trn_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85906161bc29fe6433c6e97968b9aea6b54b992e277f8219568607511523df47
+size 67766

--- a/outputs/L254.StubTranTechCalInput_CHINA.csv
+++ b/outputs/L254.StubTranTechCalInput_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4da803e8cff5634d97752c34747f6b2409f3a5c0f76b0955a084ce7392ee9a85
+size 733707

--- a/outputs/L254.StubTranTechCalInput_passthru_CHINA.csv
+++ b/outputs/L254.StubTranTechCalInput_passthru_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a205a26044304fdad0c326d456ef80b6454b22dc9f673d712cf30c001223c976
+size 51955

--- a/outputs/L254.StubTranTechCoef_CHINA.csv
+++ b/outputs/L254.StubTranTechCoef_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:993375f49c2e3f5561d018111dcff99de011eabaef4c330ff31e2ef503d319ac
+size 3825263

--- a/outputs/L254.StubTranTechCost_CHINA.csv
+++ b/outputs/L254.StubTranTechCost_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d6ba680ca44f7c9018e1cf8672f6f2d319da64809ea129ae3c202597e43e9de
+size 3311213

--- a/outputs/L254.StubTranTechLoadFactor_CHINA.csv
+++ b/outputs/L254.StubTranTechLoadFactor_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36c66678ca0803e203227ced725093dc11038e3236546b43da493191509b7bed
+size 2638846

--- a/outputs/L254.StubTranTechProd_nonmotor_CHINA.csv
+++ b/outputs/L254.StubTranTechProd_nonmotor_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbb3bffa990b2c589d492b3b9ea6a4828f528149e85cc026f57ffb2a05e55749
+size 8621

--- a/outputs/L254.StubTranTech_CHINA.csv
+++ b/outputs/L254.StubTranTech_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bac02044adacd764e136d0fb60e1c2e8e1303f5109c67610b012559aaeb0590
+size 97797

--- a/outputs/L254.StubTranTech_nonmotor_CHINA.csv
+++ b/outputs/L254.StubTranTech_nonmotor_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0044c048e256d0fd362a64228086bd8bef5e713bf06022d53d2786f429fbe947
+size 1635

--- a/outputs/L254.StubTranTech_passthru_CHINA.csv
+++ b/outputs/L254.StubTranTech_passthru_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26904bf2a14634c4aad86aad38b60ca393b0ec1e2612243fac1006b131c7048b
+size 5232

--- a/outputs/L254.Supplysector_absolute-cost-logit_CHINA.csv
+++ b/outputs/L254.Supplysector_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:280d5b794f184cc6db62028351206a05c9e5bf69e3e008a9165f0eca41ae48aa
+size 1517

--- a/outputs/L254.Supplysector_relative-cost-logit_CHINA.csv
+++ b/outputs/L254.Supplysector_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f7e3f5abb44d0f3f5a6609649e96d9e8a72d43e038b167636e5e0b7a588f2fe
+size 11945

--- a/outputs/L254.Supplysector_trn_CHINA.csv
+++ b/outputs/L254.Supplysector_trn_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2667b17fe72f05fa5021ed35c77aee0055286a4584ebc0b36aad2c752d4f80a
+size 20219

--- a/outputs/L254.tranSubsectorFuelPref_CHINA.csv
+++ b/outputs/L254.tranSubsectorFuelPref_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e2f8c3605fac764751cac694ee7427627394940e5d089bcbb2057b85f8b5163
+size 6700

--- a/outputs/L254.tranSubsectorInterp_CHINA.csv
+++ b/outputs/L254.tranSubsectorInterp_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dbc0725ef07224ee89a6da0ac409b3fda91ffca97d8f45d8b7102733e902d1b
+size 72223

--- a/outputs/L254.tranSubsectorLogit_CHINA.csv
+++ b/outputs/L254.tranSubsectorLogit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0198677091f103d9a566d93cd20dc3f8dc810bb2374e078156d81b671a1e51b5
+size 47226

--- a/outputs/L254.tranSubsectorShrwtFllt_CHINA.csv
+++ b/outputs/L254.tranSubsectorShrwtFllt_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:360e8b7d487f111b6ae5c9c2077d5a36fd904cadaa099005d6b89baa4b28b223
+size 46162

--- a/outputs/L254.tranSubsectorSpeed_CHINA.csv
+++ b/outputs/L254.tranSubsectorSpeed_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb9d4a156774d7d3c91b34b57b49bce5c023a771566c69bf09f3d67ed7774995
+size 2207284

--- a/outputs/L254.tranSubsectorSpeed_noVOTT_CHINA.csv
+++ b/outputs/L254.tranSubsectorSpeed_noVOTT_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d96870284b82e462eae03a72fa24d2c40c36c61835e3b8a852bf6b860ac114b
+size 103864

--- a/outputs/L254.tranSubsectorSpeed_nonmotor_CHINA.csv
+++ b/outputs/L254.tranSubsectorSpeed_nonmotor_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42bae695803b2bb1dec9f56a286df91f9211f41322bd4efd8d8f6ac0163431f
+size 39250

--- a/outputs/L254.tranSubsectorSpeed_passthru_CHINA.csv
+++ b/outputs/L254.tranSubsectorSpeed_passthru_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69d4221324565254ad32ef42e0d1ca9b6b4e33cff8b1493d29d183853dc5d5a3
+size 24532

--- a/outputs/L254.tranSubsectorVOTT_CHINA.csv
+++ b/outputs/L254.tranSubsectorVOTT_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bab937090e06ea04829bd203d2bf837ea55e80bff6ea92b254388cae041e02a
+size 21467

--- a/outputs/L254.tranSubsector_absolute-cost-logit_CHINA.csv
+++ b/outputs/L254.tranSubsector_absolute-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b7d571a571b4723859206b9dad52646170e6dbe1c6c0739cbc0516337d70b1b
+size 61459

--- a/outputs/L254.tranSubsector_relative-cost-logit_CHINA.csv
+++ b/outputs/L254.tranSubsector_relative-cost-logit_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1393e75f552ad49c93a6fc60b1b76d3a60afa66f587a6a33a45c81532c219c3f
+size 46

--- a/outputs/L261.DeleteSubsector_CHINAC_CHINA.csv
+++ b/outputs/L261.DeleteSubsector_CHINAC_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:826a842910c51e192aefeb32ede2f0d8dd190903324d471f95310f56fb1d3cb6
+size 76

--- a/outputs/L261.DepRsrcCurves_provinces_CHINA.csv
+++ b/outputs/L261.DepRsrcCurves_provinces_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad85a6b5da8cd7694671f55237c907c2ff5992a4f5adae29bed3c3f3ab3b7ba3
+size 11468

--- a/outputs/L261.DepRsrc_provinces_CHINA.csv
+++ b/outputs/L261.DepRsrc_provinces_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e65ba06cf505c3d1a32250b072c14a16d5ee149e4e5fb1f9ab2b1b7e16fecd1d
+size 1383

--- a/outputs/L261.EQUIV_TABLE_C_CHINA.csv
+++ b/outputs/L261.EQUIV_TABLE_C_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3c038fc6e3145cc949c8edae24dc146744fd94a59cc5e49e05a31c83374efbc
+size 94

--- a/outputs/L261.StubTechMarket_C_CHINA.csv
+++ b/outputs/L261.StubTechMarket_C_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e9021a4f5cb2ac33f02da0854c9640fabb8a1a6b974ac3d2ecc8f7b91aecae0
+size 135121

--- a/outputs/L261.StubTech_C_CHINA.csv
+++ b/outputs/L261.StubTech_C_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:240d812d53e7405b98d28bd161e5e0d23ae4f45360b4de45f8436b92c801ea45
+size 4139

--- a/outputs/L261.SubsectorLogit_C_CHINA.csv
+++ b/outputs/L261.SubsectorLogit_C_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49bf07694d135a1f5c383932d1f1769e9b21c806b9e0cf9f1c447d97d05990bc
+size 4744

--- a/outputs/L261.SubsectorLogit_absolute-cost-logit_C_CHINA.csv
+++ b/outputs/L261.SubsectorLogit_absolute-cost-logit_C_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c80f4959c46b8618e07df69319bb7f76cd0f6255c13c423f0295e72a33ab820
+size 42

--- a/outputs/L261.SubsectorLogit_relative-cost-logit_C_CHINA.csv
+++ b/outputs/L261.SubsectorLogit_relative-cost-logit_C_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ef37866551d6c08666f01eb5fd2a5842ca00b7595b3ded39c450d86c86802bb
+size 5513

--- a/outputs/L261.SubsectorShrwtFllt_C_CHINA.csv
+++ b/outputs/L261.SubsectorShrwtFllt_C_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19d5501cccd263839b0006b3a2ad023f3da88f24a401cf6b5972be7f21905115
+size 3126

--- a/outputs/L261.Supplysector_C_CHINA.csv
+++ b/outputs/L261.Supplysector_C_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffcd60e840e99b35365a1781c1bd1c083f56659abd6cae628a48a818119989ec
+size 1453

--- a/outputs/L261.Supplysector_absolute-cost-logit_C_CHINA.csv
+++ b/outputs/L261.Supplysector_absolute-cost-logit_C_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b058fbddcf2dad669b2896a4bb728a5d14a957b27abee54dc76156a698cf3f3
+size 1241

--- a/outputs/L261.Supplysector_relative-cost-logit_C_CHINA.csv
+++ b/outputs/L261.Supplysector_relative-cost-logit_C_CHINA.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f978a864f3bd548c52b70586a8a1e8a5e5f883e06106290e7affe63a4449e74
+size 32


### PR DESCRIPTION
** We are not looking to merge this any time soon**.  We are keeping this open so we can reference this branch as a package dependency for the `gcamdata-China` branch on `gcamdata`.

Note this branch has been recreated by branching off of the initial data import from `gcamdata-v1.0`.